### PR TITLE
CAUTH-2512 Add CODESTEWARDS.md to react-textarea-autocomplete

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @webbergreg @maahokgit

--- a/CODESTEWARDS.md
+++ b/CODESTEWARDS.md
@@ -4,8 +4,11 @@ Code stewards are a set of people who are very familiar with the repository and 
 
 ## Current Code Stewards
 
-1. ****
-   - Email: 
+1. **Greg Webber**
+   - Email: greg.webber@innovid.com
+
+2. **Edward Ma**
+   - Email: edward.ma@innovid.com
 
 ---
 

--- a/CODESTEWARDS.md
+++ b/CODESTEWARDS.md
@@ -1,0 +1,12 @@
+# Code Stewards
+
+Code stewards are a set of people who are very familiar with the repository and can act as stakeholders and authority for design and architecture decisions. They serve as default reviewers for pull requests.
+
+## Current Code Stewards
+
+1. ****
+   - Email: 
+
+---
+
+**Note:** For questions about workflow, design decisions, or architecture, consult the code stewards listed above.


### PR DESCRIPTION
## Summary
- Add `CODESTEWARDS.md` listing stewards for react-textarea-autocomplete
- Delete `.github/CODEOWNERS` (replaced by CODESTEWARDS.md)

Part of [CAUTH-2432](https://innovidwiki.jira.com/browse/CAUTH-2432) — adding CODESTEWARDS.md to all Imposium repos. Task: [CAUTH-2512](https://innovidwiki.jira.com/browse/CAUTH-2512).

## Test plan
- [ ] `CODESTEWARDS.md` exists at repo root with correct steward entries
- [ ] `.github/CODEOWNERS` is deleted